### PR TITLE
SampleThreadLocalFilter should always remove to prevent memory leaks

### DIFF
--- a/bundle/src/main/java/com/adobe/acs/samples/filters/impl/SampleThreadLocalFilter.java
+++ b/bundle/src/main/java/com/adobe/acs/samples/filters/impl/SampleThreadLocalFilter.java
@@ -111,11 +111,13 @@ public class SampleThreadLocalFilter implements Filter, SampleThreadLocalService
             THREAD_LOCAL.set(true);
         }
 
-        // Continue processing the request chain
-        chain.doFilter(request, response);
-
-        // Good housekeeping; Clean up after yourself!!!
-        THREAD_LOCAL.remove();
+        try {
+            // Continue processing the request chain
+            chain.doFilter(request, response);
+        } finally {
+            // Good housekeeping; Clean up after yourself!!!
+            THREAD_LOCAL.remove();
+        }
     }
 
 


### PR DESCRIPTION
The filter chain could potentially throw an Exception, if this happens, the thread local is not cleaned up and remains in memory